### PR TITLE
FEAT: Add getMute, setMute, getAudioEndpointVolume methods to Session + Example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,71 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
 name = "windows"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
  "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 
 [dependencies]
 windows = { version = "0.44.0", features = [
+    "implement",
     "Win32_Media_Audio",
     "Win32_System_Com",
     "Win32_Media_Audio_Endpoints",

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -1,0 +1,32 @@
+use windows::Win32::Media::Audio::{Endpoints::{IAudioEndpointVolumeCallback, IAudioEndpointVolumeCallback_Impl}, AUDIO_VOLUME_NOTIFICATION_DATA};
+use windows_volume_control::AudioController;
+
+#[windows::core::implement(IAudioEndpointVolumeCallback)]
+struct VolumeChangeCallback;
+
+impl IAudioEndpointVolumeCallback_Impl for VolumeChangeCallback {
+    fn OnNotify(&self, pnotify: *mut AUDIO_VOLUME_NOTIFICATION_DATA) -> ::windows::core::Result<()> {
+        unsafe {
+            println!("volume changed: {}", (*pnotify).fMasterVolume);
+        }
+        return Ok(());
+    }
+}
+
+fn main() {
+    unsafe {
+        let mut controller = AudioController::init();
+        controller.GetSessions();
+        controller.GetDefaultAudioEnpointVolumeControl();
+        controller.GetAllProcessSessions();
+
+        let session = controller.get_session_by_name("master".to_string()).unwrap();
+
+        if let Some(session_endpoint_volume) = session.getAudioEndpointVolume() {
+            let volume_callback: IAudioEndpointVolumeCallback = VolumeChangeCallback {}.into();
+            session_endpoint_volume.RegisterControlChangeNotify(&volume_callback).unwrap();
+            println!("Initialised audio event listener for session 'master'");
+            loop {};
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 use session::{ApplicationSession, EndPointSession, Session};
-use std::{process::exit, ptr::null_mut};
 use windows::{
     core::Interface,
     Win32::{
-        Foundation::{GetLastError, HINSTANCE},
         Media::Audio::{
             eMultimedia, eRender, Endpoints::IAudioEndpointVolume, IAudioSessionControl,
             IAudioSessionControl2, IAudioSessionEnumerator, IAudioSessionManager2, IMMDevice,

--- a/src/session.rs
+++ b/src/session.rs
@@ -5,6 +5,7 @@ use windows::Win32::Media::Audio::ISimpleAudioVolume;
 
 use std::process::exit;
 pub trait Session {
+    unsafe fn getAudioEndpointVolume(&self) -> Option<IAudioEndpointVolume>;
     unsafe fn getName(&self) -> String;
     unsafe fn getVolume(&self) -> f32;
     unsafe fn setVolume(&self, vol: f32);
@@ -33,6 +34,10 @@ impl EndPointSession {
 }
 
 impl Session for EndPointSession {
+    unsafe fn getAudioEndpointVolume(&self) -> Option<IAudioEndpointVolume> {
+        Some(self.simple_audio_volume.clone())
+    }
+
     unsafe fn getName(&self) -> String {
         self.name.clone()
     }
@@ -91,6 +96,10 @@ impl ApplicationSession {
 }
 
 impl Session for ApplicationSession {
+    unsafe fn getAudioEndpointVolume(&self) -> Option<IAudioEndpointVolume> {
+        None
+    }
+
     unsafe fn getName(&self) -> String {
         self.name.clone()
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,3 +1,4 @@
+use windows::Win32::Foundation::BOOL;
 use windows::core::GUID;
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
 use windows::Win32::Media::Audio::ISimpleAudioVolume;
@@ -62,7 +63,7 @@ impl Session for EndPointSession {
             .GetMute()
             .unwrap_or_else(|err| {
                 eprintln!("ERROR: Couldn't get mute {err}");
-                false
+                BOOL(0)
             })
             .as_bool()
     }
@@ -107,5 +108,21 @@ impl Session for ApplicationSession {
             .unwrap_or_else(|err| {
                 eprintln!("ERROR: Couldn't set volume: {err}");
             });
+    }
+    unsafe fn setMute(&self, mute: bool) {
+        self.simple_audio_volume
+            .SetMute(mute, &self.guid)
+            .unwrap_or_else(|err| {
+                eprintln!("ERROR: Couldn't set mute: {err}");
+        });
+    }
+    unsafe fn getMute(&self) -> bool {
+        self.simple_audio_volume
+            .GetMute()
+            .unwrap_or_else(|err| {
+                eprintln!("ERROR: Couldn't get mute {err}");
+                BOOL(0)
+            })
+            .as_bool()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,8 @@ pub trait Session {
     unsafe fn getName(&self) -> String;
     unsafe fn getVolume(&self) -> f32;
     unsafe fn setVolume(&self, vol: f32);
+    unsafe fn getMute(&self) -> bool;
+    unsafe fn setMute(&self, mute: bool);
 }
 
 pub struct EndPointSession {
@@ -47,6 +49,22 @@ impl Session for EndPointSession {
             .unwrap_or_else(|err| {
                 eprintln!("ERROR: Couldn't set volume: {err}");
             });
+    }
+    unsafe fn setMute(&self, mute: bool) {
+        self.simple_audio_volume
+            .SetMute(mute, &self.guid)
+            .unwrap_or_else(|err| {
+                eprintln!("ERROR: Couldn't set mute: {err}");
+        });
+    }
+    unsafe fn getMute(&self) -> bool {
+        self.simple_audio_volume
+            .GetMute()
+            .unwrap_or_else(|err| {
+                eprintln!("ERROR: Couldn't get mute {err}");
+                false
+            })
+            .as_bool()
     }
 }
 


### PR DESCRIPTION
 The proposed changes add `getMute`, `setMute`, and `getAudioEndpointVolume` methods to an audio session instance.

The AudioEndpointVolume can be used to register an audio notification callback handler for detecting when the volume is changed, muted, unmuted etc. An example has been added to `examples/listen.rs`